### PR TITLE
use ember-cli-build instead of config/environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ environments. To include it in production, add this
 to your config:
 
 ```js
-// config/environment.js
-if (environment === 'production') {
-  ENV['ember-faker'] = {
-    enabled: true
-  };
-}
+// ember-cli-build.js
+let app = new EmberApp(defaults, {
+  'ember-faker': {
+    enabled: EmberApp.env === 'production'
+  }
+});
 ```
 
 ## Development

--- a/index.js
+++ b/index.js
@@ -29,9 +29,15 @@ module.exports = {
 
   _getAddonConfig() {
     const app = this._findHost ? this._findHost() : this.app;
-    return Object.assign({
-      enabled: app.env !== 'production'
-    }, app.project.config(app.env)['ember-faker']);
+    return Object.assign(
+      {
+        enabled: app.env !== 'production'
+      },
+      // old way, to deprecate
+      app.project.config(app.env)['ember-faker'],
+      // new hotness
+      app.options['ember-faker']
+    );
   },
 
   _shouldInclude() {

--- a/node-tests/import-test.js
+++ b/node-tests/import-test.js
@@ -33,25 +33,54 @@ describe('import', function() {
     });
   });
 
-  it('includes faker in production when enabled is set to true', function() {
-    process.env.EMBER_ENV = 'production';
-    const addon = new EmberAddon({
-      configPath: 'tests/fixtures/config/environment-enabled'
+  describe('config/environment', function() {
+    it('includes faker in production when enabled is set to true', function() {
+      process.env.EMBER_ENV = 'production';
+      const addon = new EmberAddon({
+        configPath: 'tests/fixtures/config/environment-enabled'
+      });
+
+      expect(addon._scriptOutputFiles['/assets/vendor.js']).to.include(
+        'vendor/ember-faker/shim.js'
+      );
     });
 
-    expect(addon._scriptOutputFiles['/assets/vendor.js']).to.include(
-      'vendor/ember-faker/shim.js'
-    );
+    it('excludes faker in development when enabled is set to false', function() {
+      const addon = new EmberAddon({
+        configPath: 'tests/fixtures/config/environment-disabled'
+      });
+
+      expect(addon._scriptOutputFiles['/assets/vendor.js']).to.not.include(
+        'vendor/ember-faker/shim.js'
+      );
+    });
   });
 
-  it('excludes faker in development when enabled is set to false', function() {
-    const addon = new EmberAddon({
-      configPath: 'tests/fixtures/config/environment-disabled'
+  describe('ember-cli-build', function() {
+    it('includes faker in production when enabled is set to true', function() {
+      process.env.EMBER_ENV = 'production';
+      const addon = new EmberAddon({
+        'ember-faker': {
+          enabled: true
+        }
+      });
+
+      expect(addon._scriptOutputFiles['/assets/vendor.js']).to.include(
+        'vendor/ember-faker/shim.js'
+      );
     });
 
-    expect(addon._scriptOutputFiles['/assets/vendor.js']).to.not.include(
-      'vendor/ember-faker/shim.js'
-    );
+    it('excludes faker in development when enabled is set to false', function() {
+      const addon = new EmberAddon({
+        'ember-faker': {
+          enabled: false
+        }
+      });
+
+      expect(addon._scriptOutputFiles['/assets/vendor.js']).to.not.include(
+        'vendor/ember-faker/shim.js'
+      );
+    });
   });
 
 });


### PR DESCRIPTION
Options in config/environment.js get serialized into meta in index.html, whereas keys in ember-cli-build.js don't. Since this option is only needed at build time, not run time, we should move this to ember-cli-build.js.

This of course would be a breaking change.