### PR TITLE
Use `this.import` instead of `app.import`

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,11 +14,11 @@ module.exports = {
     }
   },
 
-  included(app) {
+  included() {
     this._super.included.apply(this, arguments);
 
     if (this._shouldInclude()) {
-      app.import('vendor/ember-faker/shim.js', {
+      this.import('vendor/ember-faker/shim.js', {
         type: 'vendor',
         exports: {
           faker: ['default']


### PR DESCRIPTION
This PR updates `ember-faker`'s addon entry point to use [`this.import`](https://github.com/ember-cli/ember-cli/blob/master/lib/models/addon.js#L784) instead of `app.import`.

Using `this.import` ensures that `vendor/ember-faker/shim.js` is _always_ imported to the top-level application. When using `app.import` (specifically the argument passed to `included`) it's possible for this asset to be imported to a lazy engine where the engine ultimately never bundles that asset within the engine. This is because it's possible for `ember-faker` to exist at multiple points in the dependency graph, and `ember-engines` ultimately dedupes `ember-faker` out as part of its `treeFor` methods assuming it also exists as part of a more common host. This causes a build error when source maps are enabled, specifically here: https://github.com/ef4/fast-sourcemap-concat/blob/master/lib/source-map.js#L85.

Having `ember-faker` always bundled with the top-level application (rather than possibly being duplicated across different lazy engines) is reasonable since it's generally expected that this is only ever included in dev/test builds.